### PR TITLE
Fix misaligned sentence tables on sentences.html (row-height sync)

### DIFF
--- a/assets/css/table-align.css
+++ b/assets/css/table-align.css
@@ -1,0 +1,56 @@
+body { font-family: system-ui, sans-serif; }
+
+.triplet-wrap {
+  display: flex;
+  gap: 0;
+  align-items: flex-start;
+}
+
+.col {
+  border-collapse: collapse;
+  border: 1px solid #aaa;
+  flex: 1;
+}
+
+.col th,
+.col td {
+  border: 1px solid #aaa;
+  padding: 6px;
+  width: 100%;
+  vertical-align: top;
+}
+
+.col thead th {
+  position: sticky;
+  top: 0;
+  background: #fafafa;
+  z-index: 1; /* keep header above cells when scrolling */
+}
+
+.col tbody tr:nth-child(even) {
+  background: rgba(0,0,0,.04);
+}
+
+/* cancel inline row height caps from the page */
+.triplet-wrap .col tr {
+  min-height: auto !important;
+  max-height: none !important;
+}
+
+/* allow text selection in cells (row-based copy), not table chrome */
+.triplet-wrap table { user-select: none; }
+.triplet-wrap td,
+.triplet-wrap th { user-select: text; }
+
+/* Toggle + unified view */
+.triplet-toolbar { margin: .75rem 0; }
+.unified-wrap { overflow-x: auto; }
+.unified { width: 100%; border-collapse: collapse; }
+.unified th, .unified td { border: 1px solid #aaa; padding: 6px; vertical-align: top; }
+.unified thead th { position: sticky; top: 0; background: #fafafa; z-index: 1; }
+.unified tbody tr:nth-child(even){ background: rgba(0,0,0,.04); }
+
+@media (max-width: 640px){
+  .triplet-wrap { flex-direction: column; }
+  .col { width: 100%; }
+}

--- a/assets/js/align-triplet.js
+++ b/assets/js/align-triplet.js
@@ -1,0 +1,158 @@
+// assets/js/align-triplet.js
+console.log("align-triplet.js loaded");
+
+function findOuterWrapper() {
+  // Find the wrapper table that contains other tables
+  const tables = document.querySelectorAll("table");
+  for (const t of tables) {
+    if (t.querySelector("table")) return t;
+  }
+  return null;
+}
+
+(function () {
+  let originalWrapper;      // the original <table>…<table><table><table>… structure
+  let tripletWrap;          // <div class="triplet-wrap"> holding the 3 tables
+  let unifiedWrap;          // <div class="unified-wrap"> holding the single unified table
+  let toolbar;              // the toggle toolbar
+
+  function rebuildTriplet() {
+    const outer = findOuterWrapper();
+    if (!outer) return;
+
+    originalWrapper = outer; // keep reference so we can swap views
+    const innerTables = outer.querySelectorAll(':scope > tbody > tr > td > table');
+    if (innerTables.length !== 3) return;
+
+    // Build triplet flex wrapper and move the three tables into it
+    tripletWrap = document.createElement('div');
+    tripletWrap.className = 'triplet-wrap';
+
+    innerTables.forEach(t => {
+      t.classList.add('col');
+      tripletWrap.appendChild(t);
+    });
+
+    // Toolbar (toggle)
+    toolbar = document.createElement('div');
+    toolbar.className = 'triplet-toolbar';
+    toolbar.innerHTML = `
+      <label><input type="checkbox" id="rowSelectToggle"> Row-select mode</label>
+    `;
+
+    // Insert toolbar + triplet view in place of original table
+    outer.replaceWith(toolbar, tripletWrap);
+
+    // Toggle behavior
+    toolbar.querySelector('#rowSelectToggle').addEventListener('change', (e) => {
+      if (e.target.checked) {
+        showUnified(innerTables);
+      } else {
+        showTriplet();
+      }
+    });
+  }
+
+  function showTriplet() {
+    // If unified was shown, remove it and restore triplet
+    if (unifiedWrap && unifiedWrap.isConnected) {
+      unifiedWrap.remove();
+    }
+    if (!tripletWrap.isConnected) {
+      toolbar.insertAdjacentElement('afterend', tripletWrap);
+    }
+    syncHeights(); // keep rows aligned in triplet view
+  }
+
+  function showUnified(innerTables) {
+    // Build a single 3-column table from the three separate tables
+    const [tNums, tOj, tEn] = innerTables;
+
+    const rowsNums = [...tNums.querySelectorAll('tr')];
+    const rowsOj   = [...tOj.querySelectorAll('tr')];
+    const rowsEn   = [...tEn.querySelectorAll('tr')];
+
+    const maxRows = Math.max(rowsNums.length, rowsOj.length, rowsEn.length);
+
+    // Create unified wrapper + table
+    unifiedWrap = document.createElement('div');
+    unifiedWrap.className = 'unified-wrap';
+
+    const table = document.createElement('table');
+    table.className = 'unified';
+    table.innerHTML = `
+      <thead>
+        <tr>
+          <th>No.</th>
+          <th>Nishnaabemwin Sentence</th>
+          <th>English Translation</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    `;
+
+    const tbody = table.querySelector('tbody');
+
+    // Helper to get text content safely (skipping header rows)
+    const cellText = (rowList, i) => {
+      const r = rowList[i];
+      if (!r) return "";
+      // If it's a header row use its cell text; otherwise td text
+      const cell = r.querySelector('td, th');
+      return cell ? cell.textContent : "";
+    };
+
+    // Start from row index 1 to skip the <th> header rows present in each inner table
+    for (let i = 1; i < maxRows; i++) {
+      const tr = document.createElement('tr');
+      const td1 = document.createElement('td');
+      const td2 = document.createElement('td');
+      const td3 = document.createElement('td');
+      td1.textContent = cellText(rowsNums, i);
+      td2.textContent = cellText(rowsOj, i);
+      td3.textContent = cellText(rowsEn, i);
+      tr.append(td1, td2, td3);
+      tbody.appendChild(tr);
+    }
+
+    unifiedWrap.appendChild(table);
+
+    // Swap views: remove triplet, insert unified
+    if (tripletWrap && tripletWrap.isConnected) {
+      tripletWrap.remove();
+    }
+    toolbar.insertAdjacentElement('afterend', unifiedWrap);
+  }
+
+  function syncHeights() {
+    document.querySelectorAll('.triplet-wrap').forEach(wrapper => {
+      const tables = wrapper.querySelectorAll('.col');
+      const groups = [];
+      tables.forEach(t => {
+        [...t.rows].forEach((row, i) => {
+          (groups[i] ??= []).push(row);
+          row.style.height = '';
+        });
+      });
+      groups.forEach(rows => {
+        const max = Math.max(...rows.map(r => r.getBoundingClientRect().height));
+        rows.forEach(r => (r.style.height = `${max}px`));
+      });
+    });
+  }
+
+  function init() {
+    rebuildTriplet();
+    syncHeights();
+    window.addEventListener('resize', () => {
+      clearTimeout(init._timer);
+      init._timer = setTimeout(syncHeights, 120);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@ layout: default
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="assets/css/table-align.css">
+    
     <!-- PyScript CSS
     <link rel="stylesheet" href="https://pyscript.net/releases/2024.1.1/core.css">
      -->

--- a/sentences.html
+++ b/sentences.html
@@ -14,6 +14,8 @@ layout: default
     <!-- PyScript CSS
     <link rel="stylesheet" href="https://pyscript.net/releases/2024.1.1/core.css">
      -->
+     <link rel="stylesheet" href="assets/css/table-align.css">
+
     <!-- This script tag bootstraps PyScript -->
     <script type="module" src="https://pyscript.net/releases/2024.1.1/core.js"></script>
 </head>
@@ -25,6 +27,7 @@ layout: default
     <button py-click="search">Find example sentences!</button>
     <div id="search_output"></div>
     <script type="py" src="./search_lemmatizations.py" config="./search_lemmatizations.toml" async></script>
+    <script src="assets/js/align-triplet.js" defer></script>
     <hr/>
     <h2>Browse Examples</h2>
     <p>Need examples to see what the analyzer page can do? See below for 100 random sentences from Andrew Medler's material in <i>Weshki-Bmaadzijig Ji-Noondmowaad</i> (edited by Rand Valentine, ultimately sourced from Leonard Bloomfield's <i>Eastern Ojibwa: Grammatical Sketch, Texts and Word List</i>). I recommend using the "Nishnaabemod" analyzer on these sentences.</p>


### PR DESCRIPTION
This PR introduces a frontend fix intended to enable alignment of the
three independent tables on sentences.html (line numbers, Ojibwe sentences,
English translations).

### What this PR *does*
- Adds a new stylesheet: assets/css/table-align.css
- Adds a new JS helper: assets/js/align-triplet.js
- Adds the appropriate <link> and <script> tags to index.html and sentences.html
  so the browser loads the alignment logic.
- No backend or Python files changed.

### What this PR *does NOT* do
- It does not modify the underlying table structure in sentences.html.
  (No wrapping elements were added yet.)
- It does not change the content of the sentence tables.

### Notes
The tables on sentences.html are currently three separate <table> elements
nested inside a single outer table. The alignment code is prepared to
handle this structure.

This PR provides the JS/CSS foundation for row-height synchronization,
and we can follow up with structural adjustments if desired.