### PR TITLE
Populate larger_text_input from url query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # textAnalysis
 Tools for applying linguistic analyzers to text, and checking the output. The end goal is producing glossaries, lemmatizations, or interlinearizations.
+
+## Production
+
+The site is hosted live at https://bowersd.github.io/textAnalysis/
+
+## Testing locally
+
+This site is built using Github Pages and PyScript.
+
+To run locally: 
+
+```
+cd <your local github repo>
+cd .. # change to the parent directory
+python3 -m http.server 8000
+```
+
+Open http://localhost:8000/textAnalysis/index.html

--- a/main.py
+++ b/main.py
@@ -578,3 +578,21 @@ def parse_words_expanded(event):
         _after_render()
         
            
+def _autorun_parse_words_expanded_from_query():
+    try:
+        params = js.URLSearchParams.new(js.window.location.search)
+        q = params.get("q")
+        if q is None:
+            return
+        q_text = str(q)
+        if q_text in ["", "null", "undefined"]:
+            return
+        input_text = pyscript.document.querySelector("#larger_text_input")
+        if input_text is not None:
+            input_text.value = q_text
+            parse_words_expanded(None)
+    except Exception as e:
+        print("query autorun skipped:", e)
+
+
+_autorun_parse_words_expanded_from_query()


### PR DESCRIPTION
## What
Adds the ability to prepopulate larger_text_input from an external site by passing the text input as query param 'q' in the url bar.

## Open questions
- [ ] @bowersd do you use/want to document a different way to test locally? I documented the way that happens to work for me but perhaps you do something else **shrug** 

## Screen capture
<img src="https://github.com/user-attachments/assets/7b925a0f-dd1f-4062-ad6b-b336cbb7fbc3" width="500" />
